### PR TITLE
Fixes server limit "bypass"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <dependency>
             <groupId>dev.masa</groupId>
             <artifactId>MaSuiteCore</artifactId>
-            <version>2.0.0-20200422.110258-17</version>
+            <version>2.0.0-20200514.135609-28</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/dev/masa/masuitehomes/bungee/controllers/SetController.java
+++ b/src/main/java/dev/masa/masuitehomes/bungee/controllers/SetController.java
@@ -39,23 +39,20 @@ public class SetController {
         Home home = plugin.getHomeService().getHomeExact(uniqueId, homeName);
         List<Home> homes = plugin.getHomeService().getHomes(uniqueId);
         loc.setServer(player.getServer().getInfo().getName());
-        if (home != null) {
-            home.setLocation(loc);
-            plugin.getHomeService().updateHome(home);
-            formator.sendMessage(player, config.load("homes", "messages.yml").getString("home.updated").replace("%home%", home.getName()));
-            plugin.listHomes(player);
-            return;
-        }
-
         long serverHomeCount = homes.stream().filter(filteredHome -> filteredHome.getLocation().getServer().equalsIgnoreCase(player.getServer().getInfo().getName())).count();
-
         if ((homes.size() < maxGlobalHomes || maxGlobalHomes == -1) && (serverHomeCount < maxServerHomes || maxServerHomes == -1)) {
+            if (home != null) {
+                home.setLocation(loc);
+                plugin.getHomeService().updateHome(home);
+                formator.sendMessage(player, config.load("homes", "messages.yml").getString("home.updated").replace("%home%", home.getName()));
+                plugin.listHomes(player);
+                return;
+            }
             Home h = plugin.getHomeService().createHome(new Home(homeName, uniqueId, loc));
             formator.sendMessage(player, config.load("homes", "messages.yml").getString("home.set").replace("%home%", h.getName()));
         } else {
             formator.sendMessage(player, config.load("homes", "messages.yml").getString("home-limit-reached"));
         }
-
         plugin.listHomes(player);
     }
 }


### PR DESCRIPTION
`/sethome` update process now checks the server & global limits when updating a home.

Also, updated to the latest core dependency to fix compile.